### PR TITLE
Fix fall calendar month mapping and tidy event rules markup

### DIFF
--- a/events.html
+++ b/events.html
@@ -44,13 +44,13 @@
 
         <section id="Event-Rules">
             <h2>Event Rules</h2>
-                <td><h3>APFs</h3></td>
-                <u1>
+                <h3>APFs</h3>
+                <ul>
                     <li>All APFs must be submitted 3 weeks in advance</li>
                     <li>You must submit an APF if you are spending money or doing anything more than a Tabling Event</li>
                     <li>APFs are reviewed by all Student Life Admin, so professionalism is very important</li>
-                    <li>Be as discriptive as possible, only submit the APF once you have all information available, Do not drip feed</li>
-                </u1>
+                    <li>Be as descriptive as possible, only submit the APF once you have all information available; do not drip feed</li>
+                </ul>
         </section>
     
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const monthNames = [
       'August','September','October','November','December'
     ];
+    const startMonth = 7; // August is month index 7 (0-based)
+    const monthsToShow = monthNames.length;
     const weekdays = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
     const year = new Date().getFullYear();
   
@@ -19,9 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     console.log('✅ Found calendar container, rendering for year', year);
   
-    for (let m = 0; m < 6; m++) {
-      const firstDay   = new Date(year, m, 1).getDay();
-      const daysInMonth = new Date(year, m + 1, 0).getDate();
+    for (let m = 0; m < monthsToShow; m++) {
+      const monthIndex = startMonth + m;
+      const firstDay   = new Date(year, monthIndex, 1).getDay();
+      const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
   
       // build month card
       const monthEl = document.createElement('div');
@@ -60,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
   
         const isoDate = [
           year,
-          String(m + 1).padStart(2, '0'),
+          String(monthIndex + 1).padStart(2, '0'),
           String(d).padStart(2, '0')
         ].join('-');
   


### PR DESCRIPTION
## Summary
- Render calendar starting from August using correct month indices
- Clean up event rules markup and fix APF guidance text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962a7d1e30832caf85197536f34572